### PR TITLE
Automate semantic version bumping via GitHub Actions

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   bump-version:
-    if: "!startsWith(github.event.head_commit.message, 'Bump version:')"
+    if: ${{ !startsWith(github.event.head_commit.message, 'Bump version:') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -30,7 +30,29 @@ jobs:
 
       - name: Determine Bump Part
         id: bump_part
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Check PR labels first (priority: labels > commit messages)
+          # We search for the PR associated with the current commit
+          # The safe navigation operator (.?) ensures we don't fail if no PR is found
+          PR_LABELS=$(gh pr list --search "${{ github.sha }}" --state merged --json labels --jq '.[0]?.labels[]?.name')
+          echo "PR Labels found: $PR_LABELS"
+
+          if echo "$PR_LABELS" | grep -q "bumpversion=major"; then
+            echo "part=major" >> $GITHUB_OUTPUT
+            echo "Detected label bumpversion=major"
+            exit 0
+          elif echo "$PR_LABELS" | grep -q "bumpversion=minor"; then
+            echo "part=minor" >> $GITHUB_OUTPUT
+            echo "Detected label bumpversion=minor"
+            exit 0
+          elif echo "$PR_LABELS" | grep -q "bumpversion=patch"; then
+            echo "part=patch" >> $GITHUB_OUTPUT
+            echo "Detected label bumpversion=patch"
+            exit 0
+          fi
+
           # Dump commits to a file to search through all messages
           echo '${{ toJson(github.event.commits) }}' > commits.json
           

--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -1,0 +1,54 @@
+name: Bump Version
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  bump-version:
+    if: "!startsWith(github.event.head_commit.message, 'Bump version:')"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Determine Bump Part
+        id: bump_part
+        run: |
+          COMMIT_MSG=$(git log -1 --pretty=%B)
+          echo "Commit message: $COMMIT_MSG"
+          
+          if echo "$COMMIT_MSG" | grep -q "#major"; then
+            echo "part=major" >> $GITHUB_OUTPUT
+            echo "Detected #major"
+          elif echo "$COMMIT_MSG" | grep -q "#minor"; then
+            echo "part=minor" >> $GITHUB_OUTPUT
+            echo "Detected #minor"
+          elif echo "$COMMIT_MSG" | grep -q "#patch"; then
+            echo "part=patch" >> $GITHUB_OUTPUT
+            echo "Detected #patch"
+          else
+            echo "part=patch" >> $GITHUB_OUTPUT
+            echo "No tag detected, defaulting to patch"
+          fi
+
+      - name: Bump Version
+        run: |
+          make bump-version PART=${{ steps.bump_part.outputs.part }}
+          git push origin main --tags

--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -31,16 +31,18 @@ jobs:
       - name: Determine Bump Part
         id: bump_part
         run: |
-          COMMIT_MSG=$(git log -1 --pretty=%B)
-          echo "Commit message: $COMMIT_MSG"
+          # Dump commits to a file to search through all messages
+          echo '${{ toJson(github.event.commits) }}' > commits.json
           
-          if echo "$COMMIT_MSG" | grep -q "#major"; then
+          # Extract messages using jq (installed on ubuntu-latest)
+          # Check for tags in priority order: major > minor > patch
+          if jq -r '.[].message' commits.json | grep -q "#major"; then
             echo "part=major" >> $GITHUB_OUTPUT
             echo "Detected #major"
-          elif echo "$COMMIT_MSG" | grep -q "#minor"; then
+          elif jq -r '.[].message' commits.json | grep -q "#minor"; then
             echo "part=minor" >> $GITHUB_OUTPUT
             echo "Detected #minor"
-          elif echo "$COMMIT_MSG" | grep -q "#patch"; then
+          elif jq -r '.[].message' commits.json | grep -q "#patch"; then
             echo "part=patch" >> $GITHUB_OUTPUT
             echo "Detected #patch"
           else
@@ -50,5 +52,13 @@ jobs:
 
       - name: Bump Version
         run: |
+          # Checkout main branch to ensure we are on the branch we want to push to
+          git checkout main
+          git pull origin main
+          
+          # Bump version using make target
+          # bump-my-version is configured in pyproject.toml to commit and tag automatically
           make bump-version PART=${{ steps.bump_part.outputs.part }}
+          
+          # Push changes and tags
           git push origin main --tags

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 
+.PHONY: all build publish publish-test clean test bump-version install-uv
+
 all: build
+
+install-uv:
+	@command -v uv >/dev/null 2>&1 || curl -LsSf https://astral.sh/uv/install.sh | sh
 
 test:
 	uv run pytest -s
@@ -16,4 +21,5 @@ publish-test:
 clean:
 	rm -rf ./build ./*.egg-info ./dist
 
-.PHONY: all build publish publish-test clean test
+bump-version:
+	uv run bump-my-version bump $(PART)

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,10 @@ install-uv:
 	@echo "Installing uv if not already available (local/dev helper only)..."
 	@command -v uv >/dev/null 2>&1 || { \
 		echo "Downloading uv installer from $(UV_INSTALL_URL)"; \
-		curl -LsSf "$(UV_INSTALL_URL)" -o /tmp/uv-install.sh; \
-		sh /tmp/uv-install.sh; \
-		rm -f /tmp/uv-install.sh; \
+		tmpfile=$$(mktemp); \
+		curl -LsSf "$(UV_INSTALL_URL)" -o "$$tmpfile"; \
+		sh "$$tmpfile"; \
+		rm -f "$$tmpfile"; \
 	}
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,21 @@
 
 all: build
 
+# URL for the uv installer script.
+# This is defined as a variable so it can be pinned or overridden if needed.
+UV_INSTALL_URL ?= https://astral.sh/uv/install.sh
+
+# Helper target for local development only.
+# Downloads and runs the uv installer script from $(UV_INSTALL_URL).
+# Review the installer script before running and do not use this target in production automation.
 install-uv:
-	@command -v uv >/dev/null 2>&1 || curl -LsSf https://astral.sh/uv/install.sh | sh
+	@echo "Installing uv if not already available (local/dev helper only)..."
+	@command -v uv >/dev/null 2>&1 || { \
+		echo "Downloading uv installer from $(UV_INSTALL_URL)"; \
+		curl -LsSf "$(UV_INSTALL_URL)" -o /tmp/uv-install.sh; \
+		sh /tmp/uv-install.sh; \
+		rm -f /tmp/uv-install.sh; \
+	}
 
 test:
 	uv run pytest -s

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ dev-dependencies = [
 ]
 
 [tool.bumpversion]
-current_version = "0.2.0"
+current_version = "0.1.2"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"
@@ -94,6 +94,11 @@ commit_args = ""
 setup_hooks = []
 pre_commit_hooks = []
 post_commit_hooks = []
+
+[[tool.bumpversion.files]]
+filename = "pyproject.toml"
+search = "version = \"{current_version}\""
+replace = "version = \"{new_version}\""
 
 [tool.isort]
 multi_line_output = 3


### PR DESCRIPTION
## Summary by Sourcery

Automate semantic version bumps on the main branch and add supporting configuration for bump-my-version.

New Features:
- Introduce a GitHub Actions workflow that automatically bumps the project version on pushes to the main branch based on PR labels or commit message markers.

Enhancements:
- Add a Makefile helper target for locally installing the uv tool to support the project workflow.
- Configure bump-my-version to update the version field in pyproject.toml when bumping versions.

Build:
- Expose a bump-version Makefile target to integrate bump-my-version into the build tooling.

CI:
- Add a bump-version GitHub Actions workflow that checks out the repo, determines the bump part (major/minor/patch), runs the bump-version Make target, and pushes the resulting commit and tags.