### PR TITLE
Trigger PyPI publish on successful Bump Version workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,8 +30,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: main
 
       - name: Install uv
         uses: astral-sh/setup-uv@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
         github.event_name == 'push' || 
         (github.event_name == 'workflow_run' && 
          github.event.workflow_run.conclusion == 'success' && 
-         startsWith(github.event.workflow_run.head_commit.message, 'Bump version:') == false)
+         !startsWith(github.event.workflow_run.head_commit.message, 'Bump version:'))
       }}
     environment: 
       name: pypi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,11 +4,22 @@ on:
   push:
     tags:
       - "v*"
+  workflow_run:
+    workflows: ["Bump Version"]
+    types:
+      - completed
 
 jobs:
   pypi-publish:
     name: Upload release to PyPI
     runs-on: ubuntu-latest
+    if: >-
+      ${{ 
+        github.event_name == 'push' || 
+        (github.event_name == 'workflow_run' && 
+         github.event.workflow_run.conclusion == 'success' && 
+         startsWith(github.event.workflow_run.head_commit.message, 'Bump version:') == false)
+      }}
     environment: 
       name: pypi
       url: https://pypi.org/p/zhaostephen-rebrn
@@ -19,6 +30,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Install uv
         uses: astral-sh/setup-uv@v3


### PR DESCRIPTION
@sourcery-ai title

## Summary by Sourcery

Update the PyPI publish workflow to also run after successful version bump workflows while ensuring it uses the main branch source and only runs on successful, non-bump version events.

CI:
- Extend the PyPI publish GitHub Actions workflow to trigger on completion of the Bump Version workflow in addition to tag pushes, with conditions to avoid running on bump-version commits and to require successful completion.
- Ensure the publish job checks out the main branch explicitly before uploading to PyPI.

@sourcery-ai review