### PR TITLE
Remove --locked flag from uv build in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
           enable-cache: true
 
       - name: Build package
-        run: uv build --locked
+        run: uv build
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,8 +30,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: main
 
       - name: Install uv
         uses: astral-sh/setup-uv@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
         github.event_name == 'push' || 
         (github.event_name == 'workflow_run' && 
          github.event.workflow_run.conclusion == 'success' && 
-         startsWith(github.event.workflow_run.head_commit.message, 'Bump version:') == false)
+         !startsWith(github.event.workflow_run.head_commit.message, 'Bump version:'))
       }}
     environment: 
       name: pypi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,11 +4,22 @@ on:
   push:
     tags:
       - "v*"
+  workflow_run:
+    workflows: ["Bump Version"]
+    types:
+      - completed
 
 jobs:
   pypi-publish:
     name: Upload release to PyPI
     runs-on: ubuntu-latest
+    if: >-
+      ${{ 
+        github.event_name == 'push' || 
+        (github.event_name == 'workflow_run' && 
+         github.event.workflow_run.conclusion == 'success' && 
+         startsWith(github.event.workflow_run.head_commit.message, 'Bump version:') == false)
+      }}
     environment: 
       name: pypi
       url: https://pypi.org/p/zhaostephen-rebrn
@@ -19,6 +30,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Install uv
         uses: astral-sh/setup-uv@v3


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update the GitHub Actions publish workflow to invoke `uv build` without the `--locked` flag when building the package before publishing to PyPI.