### PR TITLE
ci: add bumpversion=none label to skip version bump

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -99,7 +99,11 @@ jobs:
           
           echo "PR Labels found: $PR_LABELS"
 
-          if echo "$PR_LABELS" | grep -q "bumpversion=major"; then
+          if echo "$PR_LABELS" | grep -q "bumpversion=none"; then
+            echo "part=none" >> $GITHUB_OUTPUT
+            echo "Detected label bumpversion=none, skipping bump"
+            exit 0
+          elif echo "$PR_LABELS" | grep -q "bumpversion=major"; then
             echo "part=major" >> $GITHUB_OUTPUT
             echo "Detected label bumpversion=major"
             exit 0
@@ -135,6 +139,7 @@ jobs:
           fi
 
       - name: Bump Version
+        if: ${{ steps.bump_part.outputs.part != 'none' }}
         run: |
           # Checkout main branch to ensure we are on the branch we want to push to
           git checkout main


### PR DESCRIPTION
## What

Adds a new `bumpversion=none` PR label that tells the Bump Version workflow to skip the version bump entirely.

## Why

There are PRs that shouldn't trigger a version bump at all: pure CI changes, doc edits, README tweaks, internal refactors before a release window, etc. Today the workflow always bumps (defaulting to `patch` if no label is present). The only existing escape hatch is the job-level `if` that skips commits whose message starts with `Bump version:` — but that's reserved for the bump bot's own commits.

## Behaviour

- New label: `bumpversion=none`. Apply it to a PR and the merge commit will not trigger a bump or a tag/push.
- Checked **first** in the label chain — opt-out wins over any other `bumpversion=*` label. (A PR mistakenly labelled with both `bumpversion=major` and `bumpversion=none` is safer interpreted as "no bump"; an unwanted major bump is much worse than a skipped one.)
- No commit-tag (`#none`) escape hatch — keeping the change scoped to the label. Direct pushes to `main` still default to `patch`.

## How it works

1. `Determine Bump Part` step now sets `part=none` when the label is present.
2. `Bump Version` step now has `if: ${{ steps.bump_part.outputs.part != 'none' }}`, so when `part=none` the entire step (including the `git push`) is skipped.

## Mirror PRs

Same change is going out to the other three Python repos that share this CI:
- [stephen-zhao/datetime_matcher#12](https://github.com/stephen-zhao/datetime_matcher/pull/12)
- [stephen-zhao/vdts#6](https://github.com/stephen-zhao/vdts/pull/6)
- [stephen-zhao/nested_argparse#1](https://github.com/stephen-zhao/nested_argparse/pull/1)

Post-merge `bumpversion.yml` sha256: `3695349f188cb7b8b7af1fc401bfda00d4ba4281269b9f61d342d1acf326da0b`.

## Summary by Sourcery

CI:
- Update the bumpversion workflow to set the bump part to none when the bumpversion=none label is present and to skip the bump step entirely in that case.