### PR TITLE
ci: skip publish when no new version was released

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,8 @@ on:
       - completed
 
 jobs:
-  pypi-publish:
-    name: Upload release to PyPI
+  check:
+    name: Check if there is a new release to publish
     runs-on: ubuntu-latest
     if: >-
       ${{
@@ -20,6 +20,40 @@ jobs:
          github.event.workflow_run.conclusion == 'success' &&
          !startsWith(github.event.workflow_run.head_commit.message, 'Bump version:'))
       }}
+    outputs:
+      should_publish: ${{ steps.decide.outputs.should_publish }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Decide whether to publish
+        id: decide
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "Triggered by tag push; proceeding."
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # workflow_run trigger: confirm Bump Version actually produced a new tag.
+          # If the bump step was skipped (e.g. bumpversion=none label), no new tag
+          # was pushed and there is nothing to publish.
+          TAG=$(git tag --points-at HEAD --list 'v*' | head -n 1)
+          if [ -z "$TAG" ]; then
+            echo "No v* tag on main HEAD; Bump Version did not produce a release. Skipping."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Found tag $TAG on main HEAD; proceeding to publish."
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  pypi-publish:
+    name: Upload release to PyPI
+    needs: check
+    if: needs.check.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
     environment: pypi
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@ on:
     workflows: ["Bump Version"]
     types:
       - completed
+  workflow_dispatch:
 
 jobs:
   check:
@@ -15,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       ${{
+        github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
         (github.event_name == 'workflow_run' &&
          github.event.workflow_run.conclusion == 'success' &&
@@ -32,8 +34,8 @@ jobs:
       - name: Decide whether to publish
         id: decide
         run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
-            echo "Triggered by tag push; proceeding."
+          if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "Triggered by ${{ github.event_name }}; proceeding."
             echo "should_publish=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,10 +25,10 @@ jobs:
     outputs:
       should_publish: ${{ steps.decide.outputs.should_publish }}
     steps:
-      - name: Checkout main
+      - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
           fetch-depth: 0
 
       - name: Decide whether to publish
@@ -39,15 +39,25 @@ jobs:
             echo "should_publish=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # workflow_run trigger: confirm Bump Version actually produced a new tag.
-          # If the bump step was skipped (e.g. bumpversion=none label), no new tag
-          # was pushed and there is nothing to publish.
-          TAG=$(git tag --points-at HEAD --list 'v*' | head -n 1)
-          if [ -z "$TAG" ]; then
-            echo "No v* tag on main HEAD; Bump Version did not produce a release. Skipping."
+          # workflow_run trigger: look for a v* tag on any commit that is a
+          # descendant of the triggering commit and reachable from origin/main.
+          # A tag pushed by Bump Version during this run falls in that range.
+          # Anchoring to head_sha (not main HEAD) avoids a race where a later
+          # workflow_run would see an earlier run's tag and republish.
+          git fetch origin main --tags --quiet
+          HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+          NEW_TAG=$(
+            git rev-list "$HEAD_SHA..origin/main" 2>/dev/null |
+            while read sha; do
+              git tag --points-at "$sha" --list 'v*'
+            done |
+            head -n 1
+          )
+          if [ -z "$NEW_TAG" ]; then
+            echo "No new v* tag since $HEAD_SHA; Bump Version did not produce a release. Skipping publish."
             echo "should_publish=false" >> "$GITHUB_OUTPUT"
           else
-            echo "Found tag $TAG on main HEAD; proceeding to publish."
+            echo "Found new tag $NEW_TAG since $HEAD_SHA; proceeding to publish."
             echo "should_publish=true" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
## What

Two changes to `publish.yml`:

1. **Add a preflight `check` job** that gates the actual `pypi-publish` job on "did Bump Version actually produce a new release?"
2. **Add a `workflow_dispatch` trigger** so the publish workflow can be kicked off manually from the GitHub Actions UI.

## Why (1) — the publish gate

After [#16](https://github.com/stephen-zhao/rebrn/pull/16) merged, the `bumpversion=none` label correctly skipped the bump — but `publish.yml` still ran (Bump Version completed with `success`, which fires the `workflow_run` trigger), and it tried to publish the same already-released version.

## Why (2) — manual dispatch

For recovery scenarios (e.g. a previous publish failed, or you need to re-run for a specific tag), you can now hit "Run workflow" in the Actions UI instead of having to push a tag.

## How it works

`publish.yml` now has two jobs:

1. **`check`** — uses an event-aware filter and decides `should_publish`:
   - `workflow_dispatch` trigger → `true` (manual button press is itself the signal of intent).
   - `push` of a `v*` tag → `true` (the tag implies a new release).
   - `workflow_run` (Bump Version completed): looks for a `v*` tag pointing at `main`'s HEAD. Found → `true`. Not found (bump was skipped) → `false`.
2. **`pypi-publish`** — same as before, but now `needs: check` and `if: needs.check.outputs.should_publish == 'true'`. Skipped when the check decides not to publish.

The check uses "v* tag on main HEAD" rather than parsing the commit message because it's a more robust signal — it catches not just `bumpversion=none` but any future "Bump Version succeeded but pushed nothing" scenario (e.g. a transient bump failure).

## Mirror PRs

Same changes going out to the three sibling repos:
- [stephen-zhao/datetime_matcher#12](https://github.com/stephen-zhao/datetime_matcher/pull/12) (bundled with bumpversion=none feature)
- [stephen-zhao/vdts#6](https://github.com/stephen-zhao/vdts/pull/6) (bundled with bumpversion=none feature)
- [stephen-zhao/nested_argparse#2](https://github.com/stephen-zhao/nested_argparse/pull/2) (PR #1 was squash-merged before the bumpversion=none commits landed)

Post-merge `publish.yml` sha256 across all four: `e1d23618116157d1835caf30465c195288a342c039c6fff57f0d3a01b78ea246`.
